### PR TITLE
Configuração para tornar as respostas visíveis no PDF

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -73,9 +73,9 @@
     \include{cap_geometria/cap_geometria}
 
 %resposta dos exercícios
-%\ifisbook
-%\include{respostas}
-%\fi
+\ifisbook
+\include{respostas}
+\fi
 
 \backmatter
 %references

--- a/respostas.tex
+++ b/respostas.tex
@@ -1,0 +1,10 @@
+%Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 4.0 Internacional. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/4.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+
+\chapter*{Respostas dos Exercícios}
+\addcontentsline{toc}{chapter}{Respostas dos Exercícios}
+\fancyhead[RE]{Cálculo Numérico}
+\fancyhead[LO]{RESPOSTAS DOS EXERCÍCIOS}
+\fancyhead[LE,RO]{\thepage}
+
+Recomendamos ao leitor o uso criterioso das respostas aqui apresentadas. Devido a ainda muito constante atualização do livro, as respostas podem conter imprecisões e erros.
+\shipoutAnswer


### PR DESCRIPTION
O arquivo `respostas.tex` foi adaptado de <https://github.com/reamat/CalculoNumerico/blob/9f2e33a0f2e4240d953c6026693cf3835e3cdcfd/respostas.tex>